### PR TITLE
feat(autoware_joy_controller): add capabilities for Prius teleop - form autoware.squashed repo

### DIFF
--- a/control/autoware_joy_controller/config/joy_controller_g920.param.yaml
+++ b/control/autoware_joy_controller/config/joy_controller_g920.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    joy_type: G920
+    update_rate: 40.0
+    accel_ratio: 0.25
+    brake_ratio: 5.0
+    steer_ratio: 0.5
+    steering_angle_velocity: 0.1
+    accel_sensitivity: 0.25
+    brake_sensitivity: 0.5
+    control_command:
+      raw_control: false
+      velocity_gain: 3.0
+      max_forward_velocity: 2.0
+      max_backward_velocity: 3.0
+      backward_accel_ratio: 1.0

--- a/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/g920_joy_converter.hpp
+++ b/control/autoware_joy_controller/include/autoware/joy_controller/joy_converter/g920_joy_converter.hpp
@@ -1,0 +1,105 @@
+// File: g920_joy_converter.hpp
+#ifndef AUTOWARE__JOY_CONTROLLER__JOY_CONVERTER__G920_JOY_CONVERTER_HPP_
+#define AUTOWARE__JOY_CONTROLLER__JOY_CONVERTER__G920_JOY_CONVERTER_HPP_
+
+#include "autoware/joy_controller/joy_converter/joy_converter_base.hpp"
+
+#include <cstdlib>
+#include <complex>
+
+namespace autoware::joy_controller
+{
+class G920JoyConverter : public JoyConverterBase
+{
+public:
+        explicit G920JoyConverter(const sensor_msgs::msg::Joy & j) : j_(j) {}
+        
+        //float accel() const{ return (AccelPedal()- 1.0)/2; }
+        //float brake() const{ return (BrakePedal()- 1.0)/2; }
+        
+        float accel() const
+        {
+        constexpr float eps = 0.000001;
+        if (std::fabs(AccelPedal()) < eps) {
+        return 0.0f;
+        }
+        return (AccelPedal() + 1.0f)/2; //-1.0)/2
+        }
+
+
+        float brake() const
+        {
+        constexpr float eps = 0.000001;
+        if (std::fabs(BrakePedal()) < eps) {
+        return 0.0f;
+        }
+        return (BrakePedal() + 1.0f)/2 ; //-1.0)/2
+        }
+
+        float steer() const { return Steer(); }
+
+        bool shift_up() const { return CursorUpDown() == 1.0f; }
+        bool shift_down() const { return CursorUpDown() == -1.0f; }
+        bool shift_drive() const { return CursorLeftRight() == 0.0f; }
+        bool shift_reverse() const { return CursorLeftRight() == -1.0f; }
+
+        
+        bool turn_signal_left() const { return button_6(); }
+        bool turn_signal_right() const { return button_5(); }
+        bool clear_turn_signal() const { return button_4(); }
+
+        bool gate_mode() const { return button_3(); }
+
+        bool emergency_stop() const { return !reverse() && button_11(); }
+        bool clear_emergency_stop() const { return reverse() && button_11(); }
+
+        bool autoware_engage() const { return !reverse() && button_1(); }
+        bool autoware_disengage() const { return reverse() && button_1(); }
+
+        bool vehicle_engage() const { return !reverse() && button_2(); }
+        bool vehicle_disengage() const { return reverse() && button_2(); }
+
+
+
+private:
+
+        //G920 Axis Mapping
+        float Steer() const { return j_.axes.at(0); }
+        float AccelPedal() const { return j_.axes.at(1); }
+        float BrakePedal() const { return j_.axes.at(2); }
+        
+
+        float CursorLeftRight() const { return j_.axes.at(4); }
+        float CursorUpDown() const { return j_.axes.at(1); }
+
+        //float L2() const { return j_.axes.at(6); }
+        //float R2() const { return j_.axes.at(7); }
+
+
+        //G920 button mapping
+
+        bool button_1() const { return j_.buttons.at(0); } 
+        bool button_2() const { return j_.buttons.at(1); }
+        bool button_3() const{ return j_.buttons.at(2); }
+        bool button_4() const {return j_.buttons.at(3); }
+        bool button_5() const {return j_.buttons.at(4); }
+        bool button_6() const {return j_.buttons.at(5); }
+        bool button_7() const {return j_.buttons.at(6); }
+        bool button_8() const {return j_.buttons.at(7); }
+        bool button_9() const {return j_.buttons.at(8); }
+        bool button_10() const {return j_.buttons.at(9); }
+        bool button_11() const {return j_.buttons.at(10); }
+
+        const sensor_msgs::msg::Joy j_;
+        
+
+        
+
+        bool reverse() const { return button_7(); }
+
+        
+
+};
+}// namespace autoware::joy_controller
+
+#endif  // AUTOWARE__JOY_CONTROLLER__JOY_CONVERTER__G920_JOY_CONVERTER_HPP_

--- a/control/autoware_joy_controller/launch/joy_controller.launch.xml
+++ b/control/autoware_joy_controller/launch/joy_controller.launch.xml
@@ -12,7 +12,7 @@
   <arg name="output_gate_mode" default="/control/gate_mode_cmd"/>
   <arg name="output_vehicle_engage" default="/vehicle/engage"/>
 
-  <arg name="config_file" default="$(find-pkg-share autoware_joy_controller)/config/joy_controller_ds4.param.yaml"/>
+  <arg name="config_file" default="$(find-pkg-share autoware_joy_controller)/config/joy_controller_g920.param.yaml"/>
 
   <node pkg="autoware_joy_controller" exec="autoware_joy_controller" name="joy_controller" output="screen">
     <remap from="input/joy" to="$(var input_joy)"/>

--- a/control/autoware_joy_controller/launch/joy_controller_param_selection.launch.xml
+++ b/control/autoware_joy_controller/launch/joy_controller_param_selection.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="joy_type" default="ds4" description="options: ds4, g29, p65, xbox"/>
+  <arg name="joy_type" default="g920" description="options: ds4, g29, g920, p65, xbox"/>
 
   <include file="$(find-pkg-share autoware_joy_controller)/launch/joy_controller.launch.xml">
     <arg name="config_file" value="$(find-pkg-share autoware_joy_controller)/config/joy_controller_$(var joy_type).param.yaml"/>

--- a/control/autoware_joy_controller/schema/joy_controller.schema.json
+++ b/control/autoware_joy_controller/schema/joy_controller.schema.json
@@ -9,8 +9,8 @@
         "joy_type": {
           "type": "string",
           "description": "Joy controller type",
-          "default": "DS4",
-          "enum": ["P65", "DS4", "G29", "XBOX"]
+          "default": "G920",
+          "enum": ["P65", "DS4", "G29", "XBOX", "G920"]
         },
         "update_rate": {
           "type": "number",
@@ -68,7 +68,7 @@
             "max_forward_velocity": {
               "type": "number",
               "description": "Absolute max velocity to go forward",
-              "default": "20.0",
+              "default": "2.0",
               "minimum": 0
             },
             "max_backward_velocity": {

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -160,8 +160,8 @@ void AutowareJoyControllerNode::onJoy()
     joy_ = std::make_shared<const G29JoyConverter>(*msg);
   } else if (joy_type_ == "DS4") {
     joy_ = std::make_shared<const DS4JoyConverter>(*msg);
-    else if (joy_type_ == "G920") {
-      joy_ = std::make_shared<const G920JoyConverter>(*msg);
+  } else if (joy_type_ == "G920") {
+    joy_ = std::make_shared<const G920JoyConverter>(*msg);
   } else if (joy_type_ == "XBOX") {
     joy_ = std::make_shared<const XBOXJoyConverter>(*msg);
   } else {

--- a/control/autoware_joy_controller/src/joy_controller_node.cpp
+++ b/control/autoware_joy_controller/src/joy_controller_node.cpp
@@ -15,6 +15,7 @@
 #include "autoware/joy_controller/joy_controller.hpp"
 #include "autoware/joy_controller/joy_converter/ds4_joy_converter.hpp"
 #include "autoware/joy_controller/joy_converter/g29_joy_converter.hpp"
+#include "autoware/joy_controller/joy_converter/g920_joy_converter.hpp"
 #include "autoware/joy_controller/joy_converter/p65_joy_converter.hpp"
 #include "autoware/joy_controller/joy_converter/xbox_joy_converter.hpp"
 
@@ -159,6 +160,8 @@ void AutowareJoyControllerNode::onJoy()
     joy_ = std::make_shared<const G29JoyConverter>(*msg);
   } else if (joy_type_ == "DS4") {
     joy_ = std::make_shared<const DS4JoyConverter>(*msg);
+    else if (joy_type_ == "G920") {
+      joy_ = std::make_shared<const G920JoyConverter>(*msg);
   } else if (joy_type_ == "XBOX") {
     joy_ = std::make_shared<const XBOXJoyConverter>(*msg);
   } else {
@@ -277,7 +280,13 @@ void AutowareJoyControllerNode::publishControlCommand()
     cmd.lateral.steering_tire_rotation_rate = steering_angle_velocity_;
 
     if (joy_->accel()) {
-      cmd.longitudinal.acceleration = accel_ratio_ * joy_->accel();
+      double accel_ratio_limited = accel_ratio_;
+      if (twist_->twist.linear.x > max_forward_velocity_)
+      {
+        accel_ratio_limited = 0;
+      }
+
+      cmd.longitudinal.acceleration = accel_ratio_limited * joy_->accel();
       cmd.longitudinal.velocity =
         twist_->twist.linear.x + velocity_gain_ * cmd.longitudinal.acceleration;
       cmd.longitudinal.velocity =
@@ -312,8 +321,14 @@ void AutowareJoyControllerNode::publishExternalControlCommand()
 
     cmd.steering_angle = steer_ratio_ * joy_->steer();
     cmd.steering_angle_velocity = steering_angle_velocity_;
+    double accel_ratio_limited = accel_ratio_;
+    // Check if velocity is over the limit
+    if (twist_->twist.linear.x > max_forward_velocity_)
+    {
+      accel_ratio_limited = 0;
+    }
     cmd.throttle =
-      accel_ratio_ * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
+    accel_ratio_limited * calcMapping(static_cast<double>(joy_->accel()), accel_sensitivity_);
     cmd.brake = brake_ratio_ * calcMapping(static_cast<double>(joy_->brake()), brake_sensitivity_);
   }
 


### PR DESCRIPTION
## Description

This PR adds the changes we made to the [joy_controller](https://github.com/tudelft-iv/autoware.universe/tree/tudelft-main/control/autoware_joy_controller) now `autoware_joy_controller` to enable teleoperation using the remote control station.

Main changes are:

Add class files to support the new controller (G920)
Setup config and launch files accordingly
Add limit on the acceleration ratio when the maximum forward velocity is reached.
